### PR TITLE
Use anyopaque instead of c_void

### DIFF
--- a/src/c/c.zig
+++ b/src/c/c.zig
@@ -17,7 +17,7 @@ pub extern fn WriteConsoleW(
     lpBuffer: [*]const u16,
     nNumberOfCharsToWrite: windows.DWORD,
     lpNumberOfCharsWritten: ?*windows.DWORD,
-    lpReserved: ?*c_void,
+    lpReserved: ?*anyopaque,
 ) windows.BOOL;
 
 // Events


### PR DESCRIPTION
Since zig 0.9.0 has replaced `c_void` with `anyopaque` this should make the project work again.
I have tested (compiled and executed the demo) and it worked again.

See https://github.com/ziglang/zig/issues/10391#issuecomment-999838846